### PR TITLE
Add computers.scorptec.com.au

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -1670,3 +1670,4 @@ zenmarket.jp
 zoom-platform.com
 zooplus.de
 zooplus.fr
+computers.scorptec.com.au


### PR DESCRIPTION
[`computers.scorptec.com.au`](https://computers.scorptec.com.au) is the url for searching for products on [`scorptec.com.au`](https://www.scorptec.com.au/) which is already on the list.